### PR TITLE
storage: refactor storage functions into storage class

### DIFF
--- a/pb/main.py
+++ b/pb/main.py
@@ -5,12 +5,14 @@ import sys
 from aiohttp import web
 
 from pb.routes import setup_routes
+from pb.storage.base import setup_storage
 
 
 def init(loop, argv):
     app = web.Application(loop=loop)
 
     setup_routes(app)
+    setup_storage(app)
 
     return app
 

--- a/pb/routes.py
+++ b/pb/routes.py
@@ -1,5 +1,5 @@
-from pb.views.paste import PasteView
-from pb.views.pastes import PastesView
+from pb.views.object import ObjectView
+from pb.views.objects import ObjectsView
 
 
 def setup_routes(app):

--- a/pb/storage/base.py
+++ b/pb/storage/base.py
@@ -1,0 +1,70 @@
+from abc import ABCMeta, abstractmethod
+from uuid import uuid4
+
+from pb.models.object import Object
+from pb.utils.hash import hash_function
+
+
+class BaseStorage(metaclass=ABCMeta):
+    @abstractmethod
+    async def _write_body(self, uuid, read_chunk, digest):
+        return size  # noqa: F821
+
+    async def write_body(self, uuid, read_chunk):
+        digest = hash_function()
+
+        size = await self._write_body(uuid, read_chunk, digest)
+
+        return {
+            'uuid': uuid,
+            'size': size,
+            'digest': digest.digest()
+        }
+
+    @abstractmethod
+    async def _write_metadata(self, obj_metadata):
+        return
+
+    async def write_metadata(self, obj):
+        await self._write_metadata(obj.asdict())
+
+    async def create_object(self, read_chunk):
+        uuid = uuid4()
+        body_metadata = await self.write_body(uuid, read_chunk)
+
+        obj = Object.create(**body_metadata)
+
+        await self.write_metadata(obj)
+
+        return obj
+
+    @abstractmethod
+    async def _read_body(self, uuid, write_chunk):
+        return
+
+    @abstractmethod
+    async def _read_metadata(self, name):
+        return obj_metadata  # noqa: F821
+
+    async def read_object(self, name, write_chunk):
+        obj_metadata = await self._read_metadata(name)
+        obj = Object(**obj_metadata)
+
+        await self._read_body(obj.uuid, write_chunk)
+
+        return obj  # fixme?
+
+    #@abstractmethod
+    async def update_object(self):
+        return
+
+    #@abstractmethod
+    async def delete_object(self):
+        return
+
+
+def setup_storage(app):
+    # fixme
+    from pb.storage import filesystem
+
+    app['storage'] = filesystem.FilesystemStorage()

--- a/pb/views/object.py
+++ b/pb/views/object.py
@@ -1,18 +1,13 @@
 from aiohttp import web
 
-from pb.storage import filesystem
-
-
-storage_impl = filesystem
-
 
 class ObjectView(web.View):
     async def get(self):
-
+        storage = self.request.app['storage']
         stream = web.StreamResponse()
         await stream.prepare(self.request)
 
-        await storage_impl.stub(
-            self.request.match_info['name'], stream)
+        await storage.read_object(
+            self.request.match_info['name'], stream.write)
 
         return stream

--- a/pb/views/objects.py
+++ b/pb/views/objects.py
@@ -1,15 +1,9 @@
-from mimetypes import guess_type
-
 from aiohttp import web
-
-from pb.storage import filesystem
-
-
-storage_impl = filesystem
 
 
 class ObjectsView(web.View):
     async def post(self):
+        storage = self.request.app['storage']
         reader = await self.request.multipart()
 
         while True:
@@ -17,12 +11,8 @@ class ObjectsView(web.View):
             if not body_part:
                 break
 
-            paste = await storage_impl.write_body(body_part)
-            paste.generate_label(
-                label=self.request.match_info.get('name'))
-            paste.mimetype, _ = guess_type(body_part.filename)
-
-            await storage_impl.write_metadata(paste)
+            paste = await storage.create_object(body_part.read_chunk)
+            #paste.mimetype, _ = guess_type(body_part.filename)
 
             print(paste)
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,6 @@ basepython =
     python3.6
 
 [flake8]
-ignore = I201, N801
+ignore = I201, N801, E265
 import-order-stype = google
 application-import-names = pb


### PR DESCRIPTION
The storage_impl stuff is refactored into a new app-global storage key
which is initialized during app creation. This coincidentally allows
storage drivers to perform initialization.

This also implicitly specifies more or less the initial storage driver
API.