### PR TITLE
tests: add boilerplate tests for views

### DIFF
--- a/pb/storage/base.py
+++ b/pb/storage/base.py
@@ -7,6 +7,24 @@ from pb.utils.hash import hash_function
 
 class BaseStorage(metaclass=ABCMeta):
     @abstractmethod
+    async def create_object(self, read_chunk):  # pragma: no cover
+        return obj  # noqa: F821
+
+    @abstractmethod
+    async def read_object(self, name, write_chunk):  # pragma: no cover
+        return obj  # noqa: F821
+
+    #@abstractmethod
+    async def update_object(self):  # pragma: no cover
+        return
+
+    #@abstractmethod
+    async def delete_object(self):  # pragma: no cover
+        return
+
+
+class StreamStorage(BaseStorage, metaclass=ABCMeta):
+    @abstractmethod
     async def _write_body(self, uuid, read_chunk, digest):  # pragma: no cover
         return size  # noqa: F821
 
@@ -53,14 +71,6 @@ class BaseStorage(metaclass=ABCMeta):
         await self._read_body(obj.uuid, write_chunk)
 
         return obj  # fixme?
-
-    #@abstractmethod
-    async def update_object(self):
-        return
-
-    #@abstractmethod
-    async def delete_object(self):
-        return
 
 
 def setup_storage(app):

--- a/pb/storage/filesystem.py
+++ b/pb/storage/filesystem.py
@@ -3,11 +3,11 @@ from os import path
 import aiofiles
 from xdg import BaseDirectory
 
-from pb.storage.base import BaseStorage
+from pb.storage.base import StreamStorage
 from pb.utils import msgpack
 
 
-class FilesystemStorage(BaseStorage):
+class FilesystemStorage(StreamStorage):
     def __init__(self):
         self.base_directory = BaseDirectory.save_data_path('pb', 'paste')
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,5 @@ flake8-import-order>=0.8
 pytest>=3.0.5
 pyfakefs>=3.1
 pytest-asyncio>=0.5.0
+pytest-aiohttp>=0.1.3
+asynctest>=0.10.0

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+import pytest
+
+from pb.main import init
+from pb.storage.base import BaseStorage
+
+
+@pytest.fixture
+@patch.multiple(BaseStorage, __abstractmethods__=set())
+def cli(loop, test_client):
+
+    app = init(loop=loop, argv=None)
+    app['storage'] = BaseStorage()
+
+    return loop.run_until_complete(test_client(app))

--- a/tests/views/test_objects.py
+++ b/tests/views/test_objects.py
@@ -1,0 +1,22 @@
+from aiohttp import multipart
+from asynctest import patch
+
+from pb.storage.base import BaseStorage
+
+
+@patch.object(BaseStorage, 'create_object', return_value={})
+async def test_object_post(mock_create_object, cli):
+    with multipart.MultipartWriter() as writer:
+        writer.append('test')
+
+    await cli.post('/objects', data=writer, headers=writer.headers)
+
+    assert mock_create_object.call_count == 1
+
+
+@patch.object(BaseStorage, 'read_object')
+async def test_object_get(mock_read_object, cli):
+    await cli.get('/object/foo')
+
+    assert mock_read_object.call_count == 1
+    #mock_read_object.assert_called_once_with('foo')


### PR DESCRIPTION
This also refactored BaseStorage into a completely abstract class, useful for mocking a storage implementation.