### PR TITLE
human json

### DIFF
--- a/pb/response.py
+++ b/pb/response.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+from aiohttp.web_reqrep import json_response
+
+from pb.utils.json import HumanJSONEncoder
+
+
+_encoder = HumanJSONEncoder(sort_keys=True, indent=2)
+JSONResponse = partial(json_response, dumps=_encoder.encode)

--- a/pb/utils/json.py
+++ b/pb/utils/json.py
@@ -18,6 +18,18 @@ class JSONEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+class HumanJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, bytes):
+            return hexlify(obj).decode('utf-8')
+
+        return super().default(obj)
+
+
 def object_hook(dct):
     if '__uuid__' in dct:
         return uuid.UUID(hex=dct['hex'])

--- a/pb/views/objects.py
+++ b/pb/views/objects.py
@@ -1,8 +1,11 @@
 from aiohttp import web
 
+from pb.response import JSONResponse
+
 
 class ObjectsView(web.View):
     async def post(self):
+        objects = []
         storage = self.request.app['storage']
         reader = await self.request.multipart()
 
@@ -11,9 +14,8 @@ class ObjectsView(web.View):
             if not body_part:
                 break
 
-            paste = await storage.create_object(body_part.read_chunk)
-            #paste.mimetype, _ = guess_type(body_part.filename)
+            obj = await storage.create_object(body_part.read_chunk)
+            #obj.mimetype, _ = guess_type(body_part.filename)
+            objects.append(obj.asdict())
 
-            print(paste)
-
-        return web.Response(text='thx')
+        return JSONResponse(objects)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=1.2.0
+aiohttp>=1.3.3
 aiofiles>=0.3.0
 attrs>=16.3.0
 msgpack-python>=0.4.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,6 @@
+# bugs
+-e git://github.com/KeepSafe/aiohttp.git#egg=aiohttp
+
 # coverage
 coverage>=4.3.4
 

--- a/tests/utils/test_human_json.py
+++ b/tests/utils/test_human_json.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from pb.utils import json
+
+
+test_data = [
+    (
+        '"000102616263"',
+        b'\x00\x01\x02abc'
+    ),
+    (
+        '"2038-01-19T03:14:07+00:00"',
+        datetime(2038, 1, 19, 3, 14, 7, tzinfo=timezone.utc)
+    ),
+    (
+        '"f206ff9b-ceff-4132-b22e-d5d7e2a62708"',
+        uuid.UUID('f206ff9b-ceff-4132-b22e-d5d7e2a62708')
+    )
+]
+
+
+@pytest.fixture
+def encoder():
+    return json.HumanJSONEncoder()
+
+
+@pytest.mark.parametrize("json_input,native", test_data)
+def test_encode(encoder, json_input, native):
+    assert encoder.encode(native) == json_input
+
+
+def test_encode_fallback(encoder):
+    class C:
+        pass
+
+    with pytest.raises(TypeError):
+        encoder.encode(C)

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime, timezone
-from json import loads
 
 import pytest
 
@@ -25,7 +24,7 @@ test_data = [
 
 @pytest.fixture
 def encoder():
-    return json.JSONEncoder()
+    return json.JSONEncoder(sort_keys=True)
 
 
 @pytest.fixture
@@ -35,8 +34,7 @@ def decoder():
 
 @pytest.mark.parametrize("json_input,native", test_data)
 def test_encode(encoder, json_input, native):
-    # this is a little odd, because the json object is not ordered
-    assert loads(encoder.encode(native)) == loads(json_input)
+    assert encoder.encode(native) == json_input
 
 
 @pytest.mark.parametrize("json_input,native", test_data)

--- a/tests/views/test_objects.py
+++ b/tests/views/test_objects.py
@@ -1,17 +1,26 @@
+import json
 from unittest.mock import ANY
 
 from aiohttp import multipart
 from asynctest import patch
 
+from pb.models.object import Object
 from pb.storage.base import BaseStorage
 
 
-@patch.object(BaseStorage, 'create_object', return_value={})
+@patch.object(BaseStorage, 'create_object', return_value=Object(uuid=None))
 async def test_object_post(mock_create_object, cli):
     with multipart.MultipartWriter() as writer:
         writer.append('test')
 
-    await cli.post('/objects', data=writer, headers=writer.headers)
+    res = await cli.post('/objects', data=writer, headers=writer.headers)
+    assert res.status == 200
+
+    obj = json.loads(await res.text())
+
+    assert isinstance(obj, list)
+    assert len(obj) == 1
+    assert obj[0]['uuid'] is None
 
     assert mock_create_object.call_count == 1
 

--- a/tests/views/test_objects.py
+++ b/tests/views/test_objects.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 from aiohttp import multipart
 from asynctest import patch
 
@@ -19,4 +21,4 @@ async def test_object_get(mock_read_object, cli):
     await cli.get('/object/foo')
 
     assert mock_read_object.call_count == 1
-    #mock_read_object.assert_called_once_with('foo')
+    mock_read_object.assert_called_once_with('foo', ANY)


### PR DESCRIPTION
This adds a list of objects to the `POST /objects. The schema currently looks something like this:

```json
[
  {
    "create_dt": "2017-03-02T21:49:55.600672+00:00",
    "digest": "2c1ee6f2c989c955600e9fa4775d7e856f3d9606b4a3d95e38fdb19ce98d8ce4cf3fbe68f7b4b7cd74f59d32fa825a7075114038c81a363243ca29763548745f",
    "expire_dt": null,
    "label": "LB7m",
    "mimetype": null,
    "size": 3770209,
    "uuid": "83657a2a-3060-484b-a581-dc03b5656528"
  }
]
```

This is going to change significantly.